### PR TITLE
Added prodict to setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,7 @@
 [bumpversion]
-current_version = 0.10.1
+current_version = 0.10.2
 commit = True
 tag = False
 
 [bumpversion:file:./webtraversallibrary/version.py]
+

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setuptools.setup(
         "selenium>=3.141",
         "soupsieve>=2.0"
         "tld",
-        "urllib3"
+        "urllib3",
+        "prodict>=0.8"
     ],
     classifiers=[
         "Programming Language :: Python :: 3.7",

--- a/webtraversallibrary/version.py
+++ b/webtraversallibrary/version.py
@@ -16,4 +16,4 @@
 # under the License.
 
 """Maintains version info for this package."""
-__version__ = "0.10.1"
+__version__ = "0.10.2"


### PR DESCRIPTION
When installing the package from python package manager, prodict would not be available and cause an error.