### PR TITLE
Added text_local to elements_metadata

### DIFF
--- a/webtraversallibrary/js/get_element_metadata.js
+++ b/webtraversallibrary/js/get_element_metadata.js
@@ -64,6 +64,7 @@ function extractMetadata(el) {
             y: boundingBox.top + window.scrollY
         },
         text: (el.tagName.toLowerCase() == 'input' ? el.value : el.innerText),
+        text_local: Array.from(el.childNodes).filter(el => el instanceof Text).map(textEl=>textEl.textContent).join("").trim(),
         children_count: el.childElementCount,
         num_imgs: imgChildren.length - imgSvgChildren.length,
         num_svgs: svgChildren.length + imgSvgChildren.length + (el.tagName.toLowerCase() === 'svg'),


### PR DESCRIPTION
The added function loops over all the children of a node and filters out
those of type Text (consequently skipping all other children). The text
nodes are joined into a string that is returned under the key
`text_local` in `elements_metadata`.

Fixes #104 