### PR TITLE
Removed superfluous sleep() calls

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.2
+current_version = 0.11.3
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.2] - 2020-12-29
+## [0.11.3] - 2020-12-29
+- Massive performance enhancements, especially in headless mode
+
+## [0.11.2] - 2020-12-28
 - Updated user agents, split firefox into firefox_desktop and firefox_mobile
 - Added WaitForElement action
 - Fixed bug in Refresh action

--- a/webtraversallibrary/version.py
+++ b/webtraversallibrary/version.py
@@ -16,4 +16,4 @@
 # under the License.
 
 """Maintains version info for this package."""
-__version__ = "0.11.2"
+__version__ = "0.11.3"

--- a/webtraversallibrary/workflow.py
+++ b/webtraversallibrary/workflow.py
@@ -247,9 +247,6 @@ class Workflow:
         return all_views
 
     def _get_new_view(self, name: str, initial_action: Action) -> View:
-        # Ensure page is fully loaded
-        self.current_window.scraper.wait_until_loaded()
-
         # Run postload callbacks
         for cb in self.current_window.scraper.postload_callbacks:
             cb()
@@ -498,7 +495,7 @@ class Workflow:
                     )
                     self.latest_view.snapshot.screenshots[name] = scr
 
-                if self.config.debug.live:
+                if not self.config.browser.headless and self.config.debug.live:
                     self.js.highlight(action.selector, Color.from_str(self.config.debug.action_highlight_color))
                     sleep(self.config.debug.live_delay)
 

--- a/webtraversallibrary/workflow.py
+++ b/webtraversallibrary/workflow.py
@@ -495,9 +495,10 @@ class Workflow:
                     )
                     self.latest_view.snapshot.screenshots[name] = scr
 
-                if not self.config.browser.headless and self.config.debug.live:
+                if self.config.debug.live:
                     self.js.highlight(action.selector, Color.from_str(self.config.debug.action_highlight_color))
-                    sleep(self.config.debug.live_delay)
+                    if not self.config.browser.headless:
+                        sleep(self.config.debug.live_delay)
 
                 if has_element_handle:
                     patch = self.monkeypatches.check(action.target.page, action.target)  # type: ignore


### PR DESCRIPTION
Comparison:

`time python -m examples.hard_coded --config headless`

Before: `real 0m21,139s`
After: `real 0m7,268s` (34%)

`time python -m pytest . -k system_test`

Before: `real 1m38,561s`
After: `real 0m48,613s` (49%)
